### PR TITLE
Add getStroke method and improve handling of RGB to short HEX colors

### DIFF
--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -534,7 +534,7 @@
             }
             else {
               var rgb = cssRule.style.fill.substring(4).slice(0, -1).split(',').map(x => parseInt(x));
-              fill = `#${rgb[0].toString(16)}${rgb[1].toString(16)}${rgb[2].toString(16)}`;
+              fill = `#${rgb[0].toString(16)[0]}${rgb[1].toString(16)[0]}${rgb[2].toString(16)[0]}`;
             }
           }
         }
@@ -554,7 +554,7 @@
             }
             else {
               var rgb = cssRule.style.stroke.substring(4).slice(0, -1).split(',').map(x => parseInt(x));
-              stroke = `#${rgb[0].toString(16)}${rgb[1].toString(16)}${rgb[2].toString(16)}`;
+              stroke = `#${rgb[0].toString(16)[0]}${rgb[1].toString(16)[0]}${rgb[2].toString(16)[0]}`;
             }
           }
         }

--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -542,6 +542,26 @@
 
       return fill;
     },
+    
+    getStroke(stateConfig) {
+      var stroke = undefined;
+
+      for (var cssRule of this.cssRules) {
+        if (cssRule.selectorText.indexOf(`.${stateConfig.class}`) >= 0) {
+          if (cssRule.style && cssRule.style.stroke) {
+            if (cssRule.style.fill[0] === '#') {
+              stroke = cssRule.style.stroke;
+            }
+            else {
+              var rgb = cssRule.style.stroke.substring(4).slice(0, -1).split(',').map(x => parseInt(x));
+              stroke = `#${rgb[0].toString(16)}${rgb[1].toString(16)}${rgb[2].toString(16)}`;
+            }
+          }
+        }
+      }
+
+      return stroke;
+    },
 
     setTransitionFill(svgShape, fromFill, toFill, value) {
       if (value >= 1) {


### PR DESCRIPTION
getStroke method was completely missing.  Modeled it after the getFill method that was already present.

toString(16) returns 2 character values for some RGB values (i.e. 255).  This results in extra characters in the converted hex color code (#0ff0) and breaks the short code parsing.  Discarding the second character allows the code to function, but may result in quantized color values due to the discarded character.