### PR TITLE
Added option to modify the style element

### DIFF
--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -465,6 +465,11 @@
             targetClass = this.assemble(entityConfig.group.class_template, entityState, entities);
           }
 
+           if (entityConfig.group.style_template && svgElement.id === entityId) {
+            let targetStyle = this.assemble(entityConfig.group.style_template, entityState, entities);
+            $(svgElement).attr('style', targetStyle);
+          }
+
           let originalClasses = this.getArray(svgElementConfig.clonedsvgElement.classList);
 
           // Get the config for the current state
@@ -473,6 +478,11 @@
             if (stateConfig && stateConfig.class && !wasTransitionHandled) {
               targetClass = stateConfig.class;
             }
+            
+             if (stateConfig && stateConfig.style_template && !wasTransitionHandled && svgElement.id === entityId) {                    
+              let targetStyle =  this.assemble(stateConfig.style_template, entityState, entities);
+              $(svgElement).attr('style', targetStyle);
+            }          
 
             // Remove any other previously-added state classes
             for (let otherStateConfig of entityConfig.group.states) {


### PR DESCRIPTION
Added style_template functionality. This function add the option to change the style elements of the SVG items.
I use it for my Yeelights (RGB LED lights), I wanted to change the colour of the elements depending on the current colour of the lamp. Usage example:

     groups:
        - name: Yeelights
          entities:
            - light.livingroom_lamp1
          states:
            - state: 'on'
              style_template: 'fill: rgb(${entity.attributes.rgb_color})'
            - state: 'off'
              class: 'light-off'