### PR TITLE
Don't use utilities from home-assistant-polymer

### DIFF
--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -753,7 +753,7 @@
       if (entityConfig.group.action) {
         let action = entityConfig.group.action;
         if (action.service) {
-          let domain = action.domain ? action.domain : window.HAWS.extractDomain(entityId);
+          let domain = action.domain ? action.domain : entityId.substr(0, entityId.indexOf('.'));
           domain = (domain == 'group') ? 'homeassistant' : domain;
 
           let data = {};


### PR DESCRIPTION
Starting Home Assistant 0.70 we're clearly defining the custom UI and custom panel API to make sure that we can guarantee that working in future releases.

One of the steps to make a more clear API is to not allow custom UI or panels to use our internal utilities (i'm going to write a blog post about this later).

Anyway, for now, it looks like ha-floorplan only used one utility function. Instead of referencing HAWS, I've inlined that function. This should make ha-floorplan work with 0.70.

We're going to deprecate HTML imports (also more about this later) and move to JavaScript imports. More info about this later too.