### PR TITLE
Pass browser specifics sheet and cssRules into callback

### DIFF
--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -200,12 +200,12 @@
         callback();
       }
 
-      this.loadStyleSheet(this.config.stylesheet + '?cacheBuster=' + (new Date().getTime()), function (success, link) {
+      this.loadStyleSheet(this.config.stylesheet + '?cacheBuster=' + (new Date().getTime()), function (success, link, sheet, cssRules) {
         if (success) {
           this.instance.root.appendChild(link);
-          let styleSheet = link['sheet'];
+          let styleSheet = link[sheet];
           setTimeout(() => {
-            this.instance.cssRules = this.instance.getArray(styleSheet.cssRules);
+            this.instance.cssRules = this.instance.getArray(styleSheet[cssRules]);
             callback();
           }, 1000);
         }
@@ -909,7 +909,7 @@
           if (link[sheet] && link[sheet][cssRules].length) { // SUCCESS! our style sheet has loaded
             clearInterval(interval_id);                      // clear the counters
             clearTimeout(timeout_id);
-            fn.call(scope || window, true, link);           // fire the callback with success == true
+            fn.call(scope || window, true, link, sheet, cssRules);           // fire the callback with success == true
           }
         } catch (e) { } finally { }
       }, 10),                                                   // how often to check if the stylesheet is loaded
@@ -917,7 +917,7 @@
           clearInterval(interval_id);             // clear the counters
           clearTimeout(timeout_id);
           head.removeChild(link);                // since the style sheet didn't load, remove the link node from the DOM
-          fn.call(scope || window, false, link); // fire the callback with success == false
+          fn.call(scope || window, false, link, sheet, cssRules); // fire the callback with success == false
         }, 15000);                                 // how long to wait before failing
 
       head.appendChild(link);  // insert the link node into the DOM and start loading the style sheet

--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -202,8 +202,8 @@
 
       this.loadStyleSheet(this.config.stylesheet + '?cacheBuster=' + (new Date().getTime()), function (success, link, sheet, cssRules) {
         if (success) {
-          this.instance.root.appendChild(link);
           let styleSheet = link[sheet];
+          this.instance.root.appendChild(link);
           setTimeout(() => {
             this.instance.cssRules = this.instance.getArray(styleSheet[cssRules]);
             callback();


### PR DESCRIPTION
I was in the middle of opening an issue since this was effectifly crashing on my browser (chrome), but heres a simple PR to fix it (not sure how thorough it is but it seems sound.

The erro was as follows

2019-12-08 18:27:54 ERROR (MainThread) [frontend.js.latest.201911196] <myurl>/local/custom_ui/floorplan/ha-floorplan.html:208:72 Uncaught TypeError: Cannot read property 'cssRules' of null